### PR TITLE
packages.config: Invoke-Build 2.12.0

### DIFF
--- a/.nuget/packages.config
+++ b/.nuget/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Invoke-Build" version="2.9.13" />
+  <package id="Invoke-Build" version="2.12.0" />
 </packages>


### PR DESCRIPTION
Invoke-Build 2.12.0 provides only the core scripts in its package. This is just
enough for tools like PowerTasks, OneBuild, etc. Other scripts are redundant
and may even causes issues.

One issue is caused by _TabExpansionProfile.Invoke-Build.ps1_ (excluded now but
exists in 2.9.13 which comes with PowerTasks). I use TabExpansion completers
from it and I have my own version of it in the path. Thus, when Visual Studio
starts with a project with PowerTasks and I hit TabExpansion in the Package
Manager console then both files are found in the path and loaded. This is not a
fatal issue, errors are handled nice and quietly but they can be avoided if
PowerTasks just uses the latest Invoke-Build.

Besides, Invoke-Build has a number of improvements and fixes since 2.9.12.

P.S. PowerTasks looks very useful, I am looking forward to its development.
