### PR TITLE
Bugfix for newly created option to not fail on duplicate package. 

### DIFF
--- a/PowerTasks/Functions.ps1
+++ b/PowerTasks/Functions.ps1
@@ -187,7 +187,8 @@ function Push-Package($basePath, $package, $nugetPackageSource, $nugetPackageSou
 		Write-Host $out
 	}
 	catch{
-		$isDuplicatePackageError = $([String]$_).Contains("Overwriting existing packages is forbidden")	
+		$isDuplicatePackageError = $([String]$_).Contains("Overwriting existing packages is forbidden")	 -or 
+								   $([String]$_).Contains(" exists in compilation with different binary hash")
 		if(!$isDuplicatePackageError -or ($failOnDuplicatePackage -and $isDuplicatePackageError)){		
 			throw
 		}

--- a/PowerTasks/Properties/AssemblyInfo.cs
+++ b/PowerTasks/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
 ﻿using System.Reflection;
 
-[assembly: AssemblyVersion("1.2.0")]
-[assembly: AssemblyFileVersion("1.2.0")]
+[assembly: AssemblyVersion("1.2.1")]
+[assembly: AssemblyFileVersion("1.2.1")]


### PR DESCRIPTION
The same rule needs to be applied to SymbolSource (with a different search string)
