### PR TITLE
Add an optional parameter for MsBuild so we can use the latest version

### DIFF
--- a/PowerTasks/.Tasks/Compile.nuspec
+++ b/PowerTasks/.Tasks/Compile.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
 	<metadata>
 		<id>PowerTasks.Plugins.Compile</id>
-		<version>2.0.0</version>
+		<version>2.0.1</version>
 		<authors>Shayne van Asperen, Kenneth Truyers</authors>
 		<owners>Shayne van Asperen</owners>
 		<licenseUrl>https://github.com/shaynevanasperen/PowerTasks/blob/master/LICENSE</licenseUrl>

--- a/PowerTasks/.Tasks/Compile.ps1
+++ b/PowerTasks/.Tasks/Compile.ps1
@@ -3,10 +3,10 @@ $script:config = (property config "Release")
 $script:outputPath = (property outputPath (Get-OutputPath $basePath $artifactsPath $projectName))
 $script:azureTargetProfile = (property azureTargetProfile "")
 $script:projectTests = @(Get-TestProjectsFromSolution $basePath\$projectName.sln $basePath)
-$script:MsBuildVersion = (property MsBuildVersion "12.0")
+$script:msBuildVersion = (property msBuildVersion "12.0")
 
 task Compile {
-	use $MsBuildVersion MSBuild
+	use $msBuildVersion MSBuild
 	Convert-Project $config $basePath $projectName $outputPath $azureTargetProfile
 	$ilMerge = Get-PackageInfo ILMerge $basePath\$projectName
 	if ($ilMerge.Exists) {

--- a/PowerTasks/.Tasks/Compile.ps1
+++ b/PowerTasks/.Tasks/Compile.ps1
@@ -2,11 +2,11 @@ $script:artifactsPath = (property artifactsPath $basePath\artifacts)
 $script:config = (property config "Release")
 $script:outputPath = (property outputPath (Get-OutputPath $basePath $artifactsPath $projectName))
 $script:azureTargetProfile = (property azureTargetProfile "")
-
 $script:projectTests = @(Get-TestProjectsFromSolution $basePath\$projectName.sln $basePath)
+$script:MsBuildVersion = (property MsBuildVersion "12.0")
 
 task Compile {
-	use 12.0 MSBuild
+	use $MsBuildVersion MSBuild
 	Convert-Project $config $basePath $projectName $outputPath $azureTargetProfile
 	$ilMerge = Get-PackageInfo ILMerge $basePath\$projectName
 	if ($ilMerge.Exists) {


### PR DESCRIPTION
This is needed for any applications that target .NET 4.6 and will later be useful for any newer .NET versions
