### PR TITLE
Teamcity release notes

### DIFF
--- a/PowerTasks/.Tasks/TeamCityReleaseNotes.nuspec
+++ b/PowerTasks/.Tasks/TeamCityReleaseNotes.nuspec
@@ -1,0 +1,27 @@
+<?xml version="1.0"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
+	<metadata>
+		<id>PowerTasks.Plugins.TeamCityReleaseNotes</id>
+		<version>1.0.0</version>
+		<authors>Shayne van Asperen, Kenneth Truyers</authors>
+		<owners>Shayne van Asperen</owners>
+		<licenseUrl>https://github.com/shaynevanasperen/PowerTasks/blob/master/LICENSE</licenseUrl>
+		<projectUrl>https://github.com/shaynevanasperen/PowerTasks</projectUrl>
+		<iconUrl>https://raw.githubusercontent.com/shaynevanasperen/PowerTasks/master/PowerTasks.png</iconUrl>
+		<requireLicenseAcceptance>false</requireLicenseAcceptance>
+		<summary>A PowerTasks plugin which gets all git commits between the last succesful and this run on TeamCity and place them in a releasenotes file</summary>
+		<description>TeamCityReleaseNotes</description>
+		<language>en-US</language>
+		<tags>powershell, invoke, build, tasks, plugin</tags>
+		<developmentDependency>true</developmentDependency>
+		<dependencies>
+			<dependency id="PowerTasks" version="2.0.0" />
+		</dependencies>
+	</metadata>
+	<files>
+		<file src="nuspec\DUMMY.txt" target="lib" />
+		<file src="nuspec\install.ps1" target="tools" />
+		<file src="nuspec\uninstall.ps1" target="tools" />
+		<file src="TeamCityReleaseNotes.ps1" target="scripts" />
+	</files>
+</package>

--- a/PowerTasks/.Tasks/TeamCityReleaseNotes.ps1
+++ b/PowerTasks/.Tasks/TeamCityReleaseNotes.ps1
@@ -1,0 +1,52 @@
+$script:artifactsPath = (property artifactsPath $basePath\artifacts)
+
+task TeamCityReleaseNotes {
+	if([String]::IsNullOrEmpty($env:TEAMCITY_VERSION)){
+		throw "This task can only be executed on TeamCity"
+	}
+
+	$buildProperties = Load-TeamCityProperties ((Resolve-Path "$env:TEAMCITY_BUILD_PROPERTIES_FILE.xml").Path)
+	$configProperties = Load-TeamCityProperties ($buildProperties["teamcity.configuration.properties.file"] + ".xml")
+	$LatestCommitFromRun = Get-TeamCityLastSuccessfulRunCommit $configProperties["teamcity.serverUrl"] $buildProperties["teamcity.auth.userId"] $buildProperties["teamcity.auth.password"] $buildProperties["teamcity.buildType.id"]
+	if(!(Test-Path $artifactsPath)){
+		md $artifactsPath
+	}
+	Get-CommitsFromGitLog $LatestCommitFromRun $configProperties["build.vcs.number"] > "$artifactsPath\releasenotes.md"
+}
+
+function Get-CommitsFromGitLog($StartCommit, $EndCommit){
+    $gitPath = $env:TEAMCITY_GIT_PATH
+	$fs = New-Object -ComObject Scripting.FileSystemObject
+    $git = $fs.GetFile("$gitPath").shortPath
+ 
+    $cmd =  "$git log --pretty=format:""%h | %ad | %an | %s%d"" --date=short $StartCommit...$EndCommit"
+	pushd $basePath
+	$result = $(Invoke-Expression "$cmd")
+	popd
+	$result
+}
+
+function Load-TeamCityProperties($file)
+{
+	Write-Host "Loading file $file"
+	$xml = New-Object System.Xml.XmlDocument
+    $xml.XmlResolver = $null;
+    $xml.Load($file);
+    $properties = @{};
+    foreach($entry in $xml.SelectNodes("//entry")){
+        $key = $entry.key;
+        $value = $entry.'#text';
+        $properties[$key] = $value;
+		Write-Host "$key = $value"
+    }
+	$properties
+}
+
+function Get-TeamCityLastSuccessfulRunCommit($serverUrl, $username, $password, $buildTypeId)
+{
+	$AuthString = [System.Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes("$username`:$password"))
+    $Url = "$serverUrl/app/rest/buildTypes/id:$buildTypeId/builds/status:SUCCESS" 
+	Write-Host "Url is $Url"
+    $Content = Invoke-WebRequest "$Url" -Headers @{"Authorization" = "Basic $AuthString"} -UseBasicParsing
+	(Select-Xml -Content "$Content" -Xpath "/build/revisions/revision/@version").Node.Value
+}

--- a/PowerTasks/.Tasks/TeamCityReleaseNotes.ps1
+++ b/PowerTasks/.Tasks/TeamCityReleaseNotes.ps1
@@ -19,7 +19,8 @@ function Get-CommitsFromGitLog($StartCommit, $EndCommit){
 	$fs = New-Object -ComObject Scripting.FileSystemObject
     $git = $fs.GetFile("$gitPath").shortPath
  
-    $cmd =  "$git log --pretty=format:""%h | %ad | %an | %s%d"" --date=short $StartCommit...$EndCommit"
+    $cmd =  "$git log --pretty=format:""- %h | %ad | %an | %s%d"" --date=short $StartCommit...$EndCommit"
+
 	pushd $basePath
 	$result = $(Invoke-Expression "$cmd")
 	popd

--- a/PowerTasks/.Tasks/TeamCityReleaseNotes.ps1
+++ b/PowerTasks/.Tasks/TeamCityReleaseNotes.ps1
@@ -28,7 +28,6 @@ function Get-CommitsFromGitLog($StartCommit, $EndCommit){
 
 function Load-TeamCityProperties($file)
 {
-	Write-Host "Loading file $file"
 	$xml = New-Object System.Xml.XmlDocument
     $xml.XmlResolver = $null;
     $xml.Load($file);
@@ -37,7 +36,6 @@ function Load-TeamCityProperties($file)
         $key = $entry.key;
         $value = $entry.'#text';
         $properties[$key] = $value;
-		Write-Host "$key = $value"
     }
 	$properties
 }
@@ -46,7 +44,6 @@ function Get-TeamCityLastSuccessfulRunCommit($serverUrl, $username, $password, $
 {
 	$AuthString = [System.Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes("$username`:$password"))
     $Url = "$serverUrl/app/rest/buildTypes/id:$buildTypeId/builds/status:SUCCESS" 
-	Write-Host "Url is $Url"
     $Content = Invoke-WebRequest "$Url" -Headers @{"Authorization" = "Basic $AuthString"} -UseBasicParsing
 	(Select-Xml -Content "$Content" -Xpath "/build/revisions/revision/@version").Node.Value
 }

--- a/PowerTasks/PowerTasks.csproj
+++ b/PowerTasks/PowerTasks.csproj
@@ -49,6 +49,10 @@
   </ItemGroup>
   <ItemGroup>
     <None Include=".Tasks.ps1" />
+    <None Include=".Tasks\TeamCityReleaseNotes.nuspec">
+      <DependentUpon>TeamCityReleaseNotes.ps1</DependentUpon>
+    </None>
+    <None Include=".Tasks\TeamCityReleaseNotes.ps1" />
     <None Include=".Tasks\Version.nuspec">
       <DependentUpon>Version.ps1</DependentUpon>
     </None>


### PR DESCRIPTION
This plug-in can be used as standalone to dump the git commit messages to a release notes file.
I will add another plugin later which allows you to create a release on Octopus. This can then get this releasenotes file and push it up with the release
